### PR TITLE
Add support for rendering from local file and inline template

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ dependencies {
 Hopefully this should allow jitpack to build the project, and present it as a standard gradle package for Enonic XP :)
 
 ## Usage
+
 Just as you are used to with Thymeleaf in your controller
 
 ```javascript
@@ -44,6 +45,53 @@ exports.get = function(req) {
   }
 
   var view = resolve('template.ftl');
+  var html = freemarker.render(view, model);
+
+  return {
+    body: html
+  }
+};
+```
+
+You can also use inline templates instead of resolving a freemarker file.
+
+```javascript
+var freemarker = require('/lib/tineikt/freemarker');
+
+exports.get = function(req) {
+  var model = {
+     title: "Hello Freemarker!"
+  }
+
+  var html = freemarker.render({
+      template: "<h1>${title}</h1>"
+  }, model);
+
+  return {
+    body: html
+  }
+};
+```
+
+If your application has a long deployment time, you can speed up development by pointing freemarker directly at files
+on your local computer instead of in the deployed application. 
+
+Now you can just refresh the page after changing a file, instead of having to redeploy. 
+
+```javascript
+var freemarker = require('/lib/tineikt/freemarker');
+
+exports.get = function(req) {
+  var model = {
+
+  }
+
+  // I will put the resolved view back in after I'm finished testing with local file
+  // var view = resolve('template.ftl');
+  var view = {
+      baseDirPath: "/home/myuser/code/xp-my-project/src/main/resources",
+      filePath:    "/home/myuser/code/xp-my-project/src/main/resources/site/parts/article-view/article-view.ftl"
+  }  
   var html = freemarker.render(view, model);
 
   return {
@@ -92,7 +140,7 @@ You can simply add a file "*./src/main/resources/freemarker_implicit.ftl*" with 
 [#macro imagePlaceholder width height][/#macro]
 ```
 
-> **Note:**  
+> **Note**  
 > **Protip**: You can provide type checking to your Freemarker-templates by creating `@ftlvariable`
 > comments on the top of your ftl-files.
 > 

--- a/src/main/resources/lib/tineikt/freemarker.js
+++ b/src/main/resources/lib/tineikt/freemarker.js
@@ -1,4 +1,27 @@
 /**
+ *  Use `resolve(..)` to get the ResourceKey of a Freemarker file in your project
+ * @typedef {Object} ResourceKey
+ * @property {string} application The key of the xp application
+ * @property {string} path The path within the xp application
+ */
+/**
+ * Pass in a Freemarker-template as a string
+ * @typedef {Object} TextTemplate
+ * @property {string} template A string containing the Freemarker code
+ * @property {string} [baseDirPath] An optional base path to use (on your local machine).
+ *   The default value is the root inside your deployed xp application
+ */
+/**
+ * Specify a local file on your machine to use as the template.
+ * This is useful for local testing without re-deploying the application.
+ * You can just change the file and refresh the page.
+ * @typedef {Object} File
+ * @property {string} filePath The path to a file on your local machine
+ * @property {string} [baseDirPath] An optional base path to use (on your local machine).
+ *    The default value is the root inside your deployed xp application
+ */
+
+/**
  * Freemarker template related functions.
  *
  * @example
@@ -12,13 +35,28 @@ var service = __.newBean('no.tine.xp.lib.freemarker.FreemarkerService');
 /**
  * This function renders a view using Freemarker.
  *
- * @param view Location of the view. Use `resolve(..)` to resolve a view.
+ * @param {ResourceKey | TextTemplate | File} view Enonic Resource key, inline template or local file path
  * @param {object} model Model that is passed to the view.
  * @returns {string} The rendered output.
  */
 exports.render = function (view, model) {
     var processor = service.newProcessor();
-    processor.view = view;
+
+    // If using an inline template or file the base directory path can be specified
+    if (view.baseDirPath) {
+        processor.baseDirPath = view.baseDirPath;
+    }
+
+    // configure processor with correct template type
+    if (view.template) {
+        processor.textTemplate = view.template;
+    } else if(view.filePath) {
+        processor.filePath = view.filePath;
+    } else {
+        processor.view = view;
+    }
+
     processor.model = __.toScriptValue(model);
+
     return processor.process();
 };


### PR DESCRIPTION
This commit adds support for pointing to a local ftl-file on your system instead of in the deployed application. This is only intended to be used in local development of ftl-files. By pointing to the local file, instead of the deployed file the developer needs only refresh the page to see changes, instead of having to redeploy the entire application.

It also adds support for using a string (as opposed to a file) as a template.