### PR TITLE
Add support for formatting java.time objects in Freemarker

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ Example usage in Freemarker
 <p>[@localize locale='en' key='mystring'/]</p>
 ```
 
+### Formatting Dates
+
+You can format Java 8 dates (e.g. `java.time.LocalDateTime` or `java.time.ZonedDateTime`) inside your Freemarker template.
+
+The [lib-xp-time](https://github.com/ItemConsulting/lib-xp-time) XP-library provides access to the Java-types so that
+you can parse `strings` into `java.time.*` objects.
+
+```ftl
+[#-- @ftlvariable name="locale" type="java.lang.String" --]
+[#-- @ftlvariable name="date" type="java.time.ZonedDateTime" --]
+
+[#setting locale=locale]
+
+<time datetime="${date.format("ISO_OFFSET_DATE_TIME")}">
+  ${date.format("SHORT_DATE")}
+</time>
+```
+
 #### Fixing unresolved references in IntelliJ
 
 If you are using one of the IDEs from Jetbrains, a [special comment syntax](https://www.jetbrains.com/help/idea/template-data-languages.html#special-comments) 
@@ -92,7 +110,7 @@ You can simply add a file "*./src/main/resources/freemarker_implicit.ftl*" with 
 [#macro imagePlaceholder width height][/#macro]
 ```
 
-> **Note:**  
+> **Note**  
 > **Protip**: You can provide type checking to your Freemarker-templates by creating `@ftlvariable`
 > comments on the top of your ftl-files.
 > 
@@ -115,9 +133,12 @@ You are probably used to Thymeleaf and how some magic happens when you use the `
   <div data-portal-component="${component.path}" data-th-remove="tag" />
 </div>
 ```
+
 This magic is implemented using a Freemarker directive, `<@component path=component.path />`
 The same template, in Freemarker would then be.
-```html
-[#list regions.components as component]
-  [@component path=component.path /]
-[/#list]```
+
+```ftl
+[#list regions.components as comp]
+  [@component path=comp.path /]
+[/#list]
+```

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ app {
 dependencies {
 	compile "com.enonic.xp:core-api:${xpVersion}"
 	compile "com.enonic.xp:portal-api:${xpVersion}"
-	compile "org.freemarker:freemarker:2.3.31"
+	compile "org.freemarker:freemarker:2.3.32"
+	compile "no.api.freemarker:freemarker-java8:2.1.0"
 }
 
 repositories {

--- a/src/main/java/no/tine/xp/lib/freemarker/FreemarkerProcessor.java
+++ b/src/main/java/no/tine/xp/lib/freemarker/FreemarkerProcessor.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
+import no.api.freemarker.java8.Java8ObjectWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,7 @@ public final class FreemarkerProcessor {
 
 		//CONFIGURATION.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);		// Throws exceptions to log file
 		CONFIGURATION.setTemplateExceptionHandler(TemplateExceptionHandler.HTML_DEBUG_HANDLER);      // Shows exceptions on screen
+		CONFIGURATION.setObjectWrapper(new Java8ObjectWrapper(Configuration.VERSION_2_3_25));
 	}
 
 	public FreemarkerProcessor(Map<String, PortalViewFunction> viewFunctions) {


### PR DESCRIPTION
Also fikses a typo in README.md where the `component` variable crashed with the `component` directive. Renamed the variable to `comp` so that the code is runnable.